### PR TITLE
Update packet length & local state history

### DIFF
--- a/src/pc/network/lag_compensation.c
+++ b/src/pc/network/lag_compensation.c
@@ -6,7 +6,7 @@
 #include "behavior_table.h"
 #include "model_ids.h"
 
-#define MAX_LOCAL_STATE_HISTORY 30
+#define MAX_LOCAL_STATE_HISTORY 300
 struct StateHistory {
     struct MarioState m;
     struct Object marioObj;

--- a/src/pc/network/network.h
+++ b/src/pc/network/network.h
@@ -21,7 +21,7 @@ extern struct MarioState gMarioStates[];
 #define SYNC_DISTANCE_ONLY_DEATH -1.0f
 #define SYNC_DISTANCE_ONLY_EVENTS -2.0f
 #define SYNC_DISTANCE_INFINITE 0
-#define PACKET_LENGTH 3000
+#define PACKET_LENGTH 30000
 #define NETWORKTYPESTR (gNetworkType == NT_CLIENT                            \
                         ? "Client"                                           \
                         : (gNetworkType == NT_SERVER ? "Server" : " None ")) \

--- a/src/pc/network/packets/packet.h
+++ b/src/pc/network/packets/packet.h
@@ -7,7 +7,7 @@
 #include <assert.h>
 #include <stdbool.h>
 
-#define PACKET_LENGTH 3000
+#define PACKET_LENGTH 30000
 #define PACKET_DESTINATION_BROADCAST ((u8)-1)
 #define PACKET_DESTINATION_SERVER ((u8)-2)
 


### PR DESCRIPTION
Else for every player > 29, players other than the host appear as not connected.